### PR TITLE
Remove env vars that are not required

### DIFF
--- a/00-Template/config.ts
+++ b/00-Template/config.ts
@@ -3,8 +3,7 @@ const config = {
   aadAppClientSecret: process.env.AAD_APP_CLIENT_SECRET,
   appEndpoint: process.env.APP_ENDPOINT,
   blobConnectionString: process.env.BLOB_STORAGE_CONNECTION_STRING,
-  blobContainerName: process.env.BLOB_STORAGE_CONTAINER_NAME,
-  tableConnectionString: process.env.TABLE_STORAGE_CONNECTION_STRING,
+  blobContainerName: process.env.BLOB_STORAGE_CONTAINER_NAME
 };
 
 export default config;

--- a/00-Template/env/.env.local.sample
+++ b/00-Template/env/.env.local.sample
@@ -5,8 +5,6 @@ TEAMSFX_ENV=local
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=
-BOT_DOMAIN=
-BOT_ENDPOINT=
 TEAMS_APP_TENANT_ID=
 
 BLOB_STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true


### PR DESCRIPTION
Merging this PR will 

- Remove tableConnectionString from config
- Remove BOT_DOMAIN AND BOT_ENDPOINT env vars from sample file
  - Using APP_DOMAIN and APP_ENDPOINT instead